### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,22 +4,24 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-bcb429e
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       memoryLimit: 1Gi
       cpuLimit: 1000m
+
 commands:
   - id: build
     exec:
       component: tools
-      workingDir: '${PROJECTS_ROOT}/helloworld-rust'
+      workingDir: ${PROJECT_SOURCE}
       commandLine: cargo build
       group:
         kind: build
         isDefault: true        
+
   - id: run
     exec:
       component: tools
-      workingDir: '${PROJECTS_ROOT}/helloworld-rust'
+      workingDir: ${PROJECT_SOURCE}
       commandLine: cargo run
       group:
         kind: run


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
