### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: rust
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-17_11_05](https://github.com/che-samples/helloworld-rust/assets/1271546/58754137-89d6-49c4-8b9f-3035924ff2aa)


Related issue: https://github.com/eclipse/che/issues/21985

